### PR TITLE
refactor: normalize model field names

### DIFF
--- a/docs/usage/web/network.md
+++ b/docs/usage/web/network.md
@@ -124,7 +124,7 @@ with SelfServiceSystem("http://10.2.7.16:8080") as system:
     devices = system.get_online_devices()
 
     for device in devices:
-        print(device.ip, device.mac, device.loginTime)
+        print(device.ip, device.mac, device.login_time)
 ```
 
 ### 踢设备下线
@@ -135,7 +135,7 @@ with SelfServiceSystem("http://10.2.7.16:8080") as system:
     devices = system.get_online_devices()
 
     if devices:
-        system.kick_device(devices[0].sessionId)
+        system.kick_device(devices[0].session_id)
 ```
 
 ## 数据模型
@@ -145,6 +145,9 @@ with SelfServiceSystem("http://10.2.7.16:8080") as system:
 - `PortalInfo`：认证页地址、Portal 服务地址、用户 IP
 - `AuthResult`：Portal 认证结果
 - `OnlineDevice`：自助服务系统中的在线设备信息
+
+!!! note "字段命名"
+    `OnlineDevice` 使用 snake_case 字段名，例如 `login_time`、`session_id`。旧的 camelCase 属性仍可读取，但会触发 `DeprecationWarning`。
 
 ## 异步版本
 

--- a/zzupy/aio/web/network.py
+++ b/zzupy/aio/web/network.py
@@ -20,6 +20,7 @@ from zzupy.exception import (
     ParsingError,
     ZZUError,
 )
+from zzupy.logging import logger
 from zzupy.model.network import AuthResult, OnlineDevice, PortalInfo
 from zzupy.utils import (
     extract_first_html_attr,
@@ -66,18 +67,21 @@ async def discover_portal_info() -> PortalInfo:
     def _extract_auth_url(portal_url: str) -> str:
         """提取网页认证 URL"""
         parsed = urllib.parse.urlparse(portal_url)
+        if not parsed.scheme or not parsed.netloc:
+            raise ParsingError("无法从Portal URL获取认证服务器地址")
         return f"{parsed.scheme}://{parsed.netloc}"
 
     async def _get_portal_server_url(client: httpx2.AsyncClient, auth_url: str) -> str:
         """获取 Portal 服务器 URL"""
         DEFAULT_HTTP_PORT = 801
         DEFAULT_HTTPS_PORT = 802
+        hostname = urllib.parse.urlparse(auth_url).hostname
+        if hostname is None:
+            raise ParsingError("无法从认证 URL 获取 Portal 主机名")
 
         try:
             response = await client.get(f"{auth_url}/a41.js")
             js_params = _parse_js_config(response.text)
-
-            hostname = urllib.parse.urlparse(auth_url).hostname
 
             if js_params.get("enableHttps") == 0:
                 port = js_params.get("epHTTPPort", DEFAULT_HTTP_PORT)
@@ -86,9 +90,8 @@ async def discover_portal_info() -> PortalInfo:
                 port = js_params.get("enHTTPSPort", DEFAULT_HTTPS_PORT)
                 return f"https://{hostname}:{port}"
 
-        except Exception:
-            # 降级到默认配置
-            hostname = urllib.parse.urlparse(auth_url).hostname
+        except (httpx2.RequestError, ValueError) as exc:
+            logger.debug("获取 Portal 服务器配置失败，降级到默认配置: {}", exc)
             return f"http://{hostname}:{DEFAULT_HTTP_PORT}"
 
     def _parse_js_config(js_content: str) -> dict[str, int]:

--- a/zzupy/model/eas.py
+++ b/zzupy/model/eas.py
@@ -60,7 +60,7 @@ class PeriodInfo(BaseModel):
     require_theory: int | None
     """要求完成的理论学时数"""
     practice: None
-    practice_unit: str
+    practice_unit: str | None
     require_practice: None
     focus_practice: None
     focus_practice_unit: None

--- a/zzupy/model/eas.py
+++ b/zzupy/model/eas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, List
+from typing import Any, List, ClassVar
 
 from icalendar import Calendar
 from icalendar.cal import Event
@@ -434,8 +434,8 @@ class TeachingWeek(BaseModel):
 
     model_config = ConfigDict(frozen=False)
 
-    DAYS: int = 7
-    UNITS: int = 10
+    DAYS: ClassVar[int] = 7
+    UNITS: ClassVar[int] = 10
 
     lessons: dict[tuple[int, int], Lesson] = Field(default_factory=dict)
     """内部存储：仅存储非空课程，key 为 (weekday, unit)，value 为 Lesson"""

--- a/zzupy/model/eas.py
+++ b/zzupy/model/eas.py
@@ -7,7 +7,7 @@ from icalendar import Calendar
 from icalendar.cal import Event
 from pydantic import BaseModel, model_validator, ConfigDict, RootModel, Field
 from pydantic.alias_generators import to_camel
-from whenever import ZonedDateTime, Date, PlainDateTime, Instant
+from whenever import ZonedDateTime, Date, Instant, Time
 
 
 class Campus(BaseModel):
@@ -341,9 +341,7 @@ class Schedule(BaseModel):
             if time_val:
                 time_str = str(time_val).strip().zfill(4)
                 try:
-                    schedule_time = PlainDateTime.parse_strptime(
-                        time_str, format="%H%M"
-                    ).time()
+                    schedule_time = Time.parse(time_str, format="hhmm")
                     data[key] = schedule_date.at(schedule_time).assume_tz(
                         "Asia/Shanghai"
                     )

--- a/zzupy/model/eas.py
+++ b/zzupy/model/eas.py
@@ -325,9 +325,9 @@ class Schedule(BaseModel):
             return data
 
         try:
-            schedule_date = Date.parse_iso(date_str)
-        except Exception:
-            return data
+            schedule_date = Date.parse_iso(str(date_str))
+        except ValueError as exc:
+            raise ValueError(f"无法解析课程日期 date={date_str!r}") from exc
 
         time_keys = [
             "startTime",
@@ -339,14 +339,19 @@ class Schedule(BaseModel):
         for key in time_keys:
             time_val = data.get(key)
             if time_val:
+                if isinstance(time_val, ZonedDateTime):
+                    continue
+
                 time_str = str(time_val).strip().zfill(4)
                 try:
                     schedule_time = Time.parse(time_str, format="hhmm")
                     data[key] = schedule_date.at(schedule_time).assume_tz(
                         "Asia/Shanghai"
                     )
-                except Exception:
-                    pass
+                except ValueError as exc:
+                    raise ValueError(
+                        f"无法解析课程时间字段 {key}={time_val!r}"
+                    ) from exc
 
         return data
 

--- a/zzupy/model/network.py
+++ b/zzupy/model/network.py
@@ -1,34 +1,86 @@
 import json
+import warnings
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+def _warn_deprecated_alias(old_name: str, new_name: str) -> None:
+    warnings.warn(
+        f"{old_name} 已弃用，请使用 {new_name}",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 class OnlineDevice(BaseModel):
     """在线设备信息"""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     brasid: str
     """BRAS ID"""
-    downFlow: str
+    down_flow: str
     """下行流量"""
-    hostName: str = ""
+    host_name: str = ""
     """主机名"""
     ip: str
     """IP地址"""
-    loginTime: str
+    login_time: str
     """登录时间，格式为YYYY-MM-DD HH:MM:SS"""
     mac: str
     """MAC地址"""
-    sessionId: str
+    session_id: str
     """会话ID"""
-    terminalType: str
+    terminal_type: str
     """终端类型"""
-    upFlow: str
+    up_flow: str
     """上行流量"""
-    useTime: str
+    use_time: str
     """使用时间（秒）"""
-    userId: int
+    user_id: int
     """用户ID"""
+
+    @property
+    def downFlow(self) -> str:
+        _warn_deprecated_alias("OnlineDevice.downFlow", "down_flow")
+        return self.down_flow
+
+    @property
+    def hostName(self) -> str:
+        _warn_deprecated_alias("OnlineDevice.hostName", "host_name")
+        return self.host_name
+
+    @property
+    def loginTime(self) -> str:
+        _warn_deprecated_alias("OnlineDevice.loginTime", "login_time")
+        return self.login_time
+
+    @property
+    def sessionId(self) -> str:
+        _warn_deprecated_alias("OnlineDevice.sessionId", "session_id")
+        return self.session_id
+
+    @property
+    def terminalType(self) -> str:
+        _warn_deprecated_alias("OnlineDevice.terminalType", "terminal_type")
+        return self.terminal_type
+
+    @property
+    def upFlow(self) -> str:
+        _warn_deprecated_alias("OnlineDevice.upFlow", "up_flow")
+        return self.up_flow
+
+    @property
+    def useTime(self) -> str:
+        _warn_deprecated_alias("OnlineDevice.useTime", "use_time")
+        return self.use_time
+
+    @property
+    def userId(self) -> int:
+        _warn_deprecated_alias("OnlineDevice.userId", "user_id")
+        return self.user_id
 
     def dump_json(self, indent: Optional[int] = None) -> str:
         """格式化为JSON字符串"""
@@ -37,6 +89,8 @@ class OnlineDevice(BaseModel):
 
 class AuthResult(BaseModel):
     """Portal 认证结果"""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     result: int
     """认证结果"""
@@ -51,6 +105,8 @@ class AuthResult(BaseModel):
 
 class PortalInfo(BaseModel):
     """探测出的 Portal 认证信息"""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     auth_url: str
     """认证网页 URL"""

--- a/zzupy/web/network.py
+++ b/zzupy/web/network.py
@@ -20,6 +20,7 @@ from zzupy.exception import (
     ParsingError,
     ZZUError,
 )
+from zzupy.logging import logger
 from zzupy.model.network import AuthResult, OnlineDevice, PortalInfo
 from zzupy.utils import (
     extract_first_html_attr,
@@ -66,18 +67,21 @@ def discover_portal_info() -> PortalInfo:
     def _extract_auth_url(portal_url: str) -> str:
         """提取网页认证 URL"""
         parsed = urllib.parse.urlparse(portal_url)
+        if not parsed.scheme or not parsed.netloc:
+            raise ParsingError("无法从Portal URL获取认证服务器地址")
         return f"{parsed.scheme}://{parsed.netloc}"
 
     def _get_portal_server_url(client: httpx2.Client, auth_url: str) -> str:
         """获取 Portal 服务器 URL"""
         DEFAULT_HTTP_PORT = 801
         DEFAULT_HTTPS_PORT = 802
+        hostname = urllib.parse.urlparse(auth_url).hostname
+        if hostname is None:
+            raise ParsingError("无法从认证 URL 获取 Portal 主机名")
 
         try:
             response = client.get(f"{auth_url}/a41.js")
             js_params = _parse_js_config(response.text)
-
-            hostname = urllib.parse.urlparse(auth_url).hostname
 
             if js_params.get("enableHttps") == 0:
                 port = js_params.get("epHTTPPort", DEFAULT_HTTP_PORT)
@@ -86,9 +90,8 @@ def discover_portal_info() -> PortalInfo:
                 port = js_params.get("enHTTPSPort", DEFAULT_HTTPS_PORT)
                 return f"https://{hostname}:{port}"
 
-        except Exception:
-            # 降级到默认配置
-            hostname = urllib.parse.urlparse(auth_url).hostname
+        except (httpx2.RequestError, ValueError) as exc:
+            logger.debug("获取 Portal 服务器配置失败，降级到默认配置: {}", exc)
             return f"http://{hostname}:{DEFAULT_HTTP_PORT}"
 
     def _parse_js_config(js_content: str) -> dict[str, int]:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新特性**
  * 数据模型字段命名规范调整：字段从驼峰式改为蛇形式（如 `loginTime` → `login_time`、`sessionId` → `session_id`）。

* **破坏性变更**
  * `PeriodInfo.practice_unit` 现可为空。

* **改进**
  * 旧驼峰式字段仍可访问，但触发弃用警告。
  * 增强 Portal 配置解析的错误处理与字段验证。
  * 改进时间日期字段解析的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->